### PR TITLE
Add events on http routing (#1108)

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -14,7 +14,7 @@ Starts a Kuzzle instance in the foreground.
 
 # Create the first administrative user account
 
-You will need it to connect to the back-office
+You will need it to connect to the admin console
 
 ```
 $ kuzzle createFirstAdmin
@@ -27,7 +27,7 @@ will guide you through the creation process of the first admin user and fix the 
 # Reset Kuzzle
 
 ```
-$ kuzzle reset 
+$ kuzzle reset
 ```
 
 will allow you to reset Kuzzle and restore it as if it is freshly installed.
@@ -49,14 +49,12 @@ $ kuzzle reset --noint
 
 # Getting help
 
-You can, of course, get some help by using the --help option. 
+You can, of course, get some help by using the --help option.
 
-Try those: 
+Try those:
 
 ```
 $ kuzzle --help
 $ kuzzle start --help
 $ kuzzle reset --help
 ```
-
-

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -70,7 +70,7 @@ function commandStart (options) {
       return requests;
     })
     .each(rq => {
-      const 
+      const
         index = rq.input.resource.index,
         indexRequest = new Request({index});
 
@@ -144,7 +144,7 @@ function commandStart (options) {
         .then(res => {
           if (!res) {
             console.log(cout.warn('[!] [WARNING] There is no administrator user yet: everyone has administrator rights.'));
-            console.log(cout.notice('[ℹ] You can use the CLI or the back-office to create the first administrator user.'));
+            console.log(cout.notice('[ℹ] You can use the CLI or the admin console to create the first administrator user.'));
             console.log(cout.notice('    For more information: http://docs.kuzzle.io/guide/essentials/security'));
           }
         });

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -44,4 +44,3 @@ services:
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-

--- a/docker-compose/scripts/install-plugins.sh
+++ b/docker-compose/scripts/install-plugins.sh
@@ -12,7 +12,8 @@ for target in ${plugins_dir}/* ${protocols_dir}/* ; do
     echo 'Installing dependencies for ' $(basename "$target")
     cd "$target"
     npm install --unsafe
+    find -L node_modules/.bin -type f -exec chmod 776 {} \;
+    find node_modules/ -type d -exec chmod 755 {} \;
     cd "$working_dir"
   fi
 done
-

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -6,6 +6,8 @@ elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
 npm install --unsafe
 npm rebuild all --unsafe
+find -L node_modules/.bin -type f -exec chmod 776 {} \;
+find node_modules/ -type d -exec chmod 755 {} \;
 docker-compose/scripts/install-plugins.sh
 
 echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"

--- a/docker-compose/scripts/run-test.sh
+++ b/docker-compose/scripts/run-test.sh
@@ -6,6 +6,8 @@ elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
 npm install --unsafe
 npm install --unsafe --only=dev
+find -L node_modules/.bin -type f -exec chmod 776 {} \;
+find node_modules/ -type d -exec chmod 755 {} \;
 docker-compose/scripts/install-plugins.sh
 
 echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -46,4 +46,3 @@ services:
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -150,56 +150,77 @@ class Router {
         request.input.headers = httpRequest.headers;
         request.setResult({}, 200);
 
-        return this.kuzzle.pluginsManager.trigger('http:options', request)
+        this.kuzzle.pluginsManager.trigger('http:options', request)
           .then(result => {
             cb(result);
             return null;
           })
           .catch(error => replyWithError(cb, request, error));
+
+        return;
       }
 
-      return replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
+      replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
+      return;
     }
 
     httpRequest.url = httpRequest.url.replace(LeadingSlashRegex, '');
 
     try {
       const routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
+      const httpEvent = `http:${httpRequest.method.toLowerCase()}`;
 
       request = routeHandler.getRequest();
       request.response.setHeaders(this.defaultHeaders);
 
       if (routeHandler.handler === null) {
-        return replyWithError(cb, request, new NotFoundError(`API URL not found: ${routeHandler.url}`));
+        throw new NotFoundError(`API URL not found: ${routeHandler.url}`);
       }
 
       if (httpRequest.content.length <= 0) {
-        return routeHandler.invokeHandler(cb);
+        this.kuzzle.pluginsManager.trigger(httpEvent, request)
+          .then(mutatedRequest => {
+            routeHandler.request = mutatedRequest;
+
+            routeHandler.invokeHandler(cb);
+            return null;
+          })
+          .catch(error => replyWithError(cb, request, error));
+        return;
       }
 
       if (httpRequest.headers['content-type']
-        && !httpRequest.headers['content-type'].startsWith('application/json')) {
-        return replyWithError(cb, request, new BadRequestError(`Invalid request content-type. Expected "application/json", got: "${httpRequest.headers['content-type']}"`));
+      && !httpRequest.headers['content-type'].startsWith('application/json')) {
+        throw new BadRequestError(`Invalid request content-type. Expected "application/json", got: "${httpRequest.headers['content-type']}"`);
       }
 
       {
         const encoding = CharsetRegex.exec(httpRequest.headers['content-type']);
 
         if (encoding !== null && encoding[1].toLowerCase() !== 'utf-8') {
-          return replyWithError(cb, request, new BadRequestError(`Invalid request charset. Expected "utf-8", got: "${encoding[1].toLowerCase()}"`));
+          throw new BadRequestError(`Invalid request charset. Expected "utf-8", got: "${encoding[1].toLowerCase()}"`);
         }
       }
 
-      routeHandler.addContent(httpRequest.content);
-      routeHandler.invokeHandler(cb);
+      this.kuzzle.pluginsManager.trigger(httpEvent, request)
+        .then(mutatedRequest => {
+          routeHandler.request = mutatedRequest;
+
+          routeHandler.addContent(httpRequest.content);
+          routeHandler.invokeHandler(cb);
+          return null;
+        })
+        .catch(error => replyWithError(cb, request, error));
     }
     catch (err) {
       if (request === undefined) {
         request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
         request.response.setHeaders(this.defaultHeaders);
       }
+
       const e = (err instanceof KuzzleError) && err || new KuzzleInternalError(err);
       replyWithError(cb, request, e);
+      return;
     }
   }
 }

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -199,8 +199,12 @@ function registerErrorHandlers(kuzzle) {
 
   // Remove external listeners (PM2) to avoid other listeners to exit current process
   process.removeAllListeners('unhandledRejection');
-  process.on('unhandledRejection', err => {
-    console.error(`ERROR: unhandledRejection: ${err.message}`, err.stack); // eslint-disable-line no-console
+  process.on('unhandledRejection', (reason, promise) => {
+    if (reason !== undefined) {
+      console.error(`ERROR: unhandledRejection: ${reason.message}`, reason.stack, promise); // eslint-disable-line no-console
+    } else {
+      console.error('ERROR: unhandledRejection:', promise); // eslint-disable-line no-console
+    }
 
     // dump+exit is a good idea during development as it helps
     // spotting code errors. But in production, these problems

--- a/test/api/controllers/cli/cleanDb.test.js
+++ b/test/api/controllers/cli/cleanDb.test.js
@@ -16,11 +16,11 @@ describe('Test: clean database', () => {
 
   it('should erase the internal ES & Redis dbs', () => {
     kuzzle.repositories.user.search.returns(Bluebird.resolve({total: 0, hits: []}));
-    
+
     return cleanDb(null, sinon.stub())
       .then(() => {
         should(kuzzle.repositories.user.search).be.calledOnce();
-        should(kuzzle.repositories.user.scroll.called).be.false();
+        should(kuzzle.repositories.user.scroll).not.be.called();
         should(kuzzle.internalEngine.deleteIndex).be.calledOnce();
         should(kuzzle.services.list.internalCache.flushdb).be.calledOnce();
 
@@ -49,14 +49,14 @@ describe('Test: clean database', () => {
     ]}));
 
     kuzzle.repositories.user.scroll.onFirstCall().returns(Bluebird.resolve({
-      total: 1, 
-      scrollId: 'foobar2', 
+      total: 1,
+      scrollId: 'foobar2',
       hits: [{_id: 'foo4'}]
     }));
 
     kuzzle.repositories.user.scroll.onSecondCall().returns(Bluebird.resolve({
-      total: 1, 
-      scrollId: 'foobar2', 
+      total: 1,
+      scrollId: 'foobar2',
       hits: [{_id: 'foo5'}]
     }));
 

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -446,8 +446,8 @@ describe('Test: collection controller', () => {
         .then(response => {
           should(response).be.instanceof(Object);
           should(response.type).be.exactly('stored');
-          should(kuzzle.hotelClerk.getRealtimeCollections.called).be.false();
-          should(kuzzle.services.list.storageEngine.listCollections.called).be.true();
+          should(kuzzle.hotelClerk.getRealtimeCollections).not.be.called();
+          should(kuzzle.services.list.storageEngine.listCollections).be.called();
         });
     });
 
@@ -458,8 +458,8 @@ describe('Test: collection controller', () => {
         .then(response => {
           should(response).be.instanceof(Object);
           should(response.type).be.exactly('realtime');
-          should(kuzzle.hotelClerk.getRealtimeCollections.called).be.true();
-          should(kuzzle.services.list.storageEngine.listCollections.called).be.false();
+          should(kuzzle.hotelClerk.getRealtimeCollections).be.called();
+          should(kuzzle.services.list.storageEngine.listCollections).not.be.called();
         });
     });
 
@@ -477,8 +477,8 @@ describe('Test: collection controller', () => {
             {name: 'crealtime', type: 'realtime'}
           ]);
           should(response.type).be.exactly('all');
-          should(kuzzle.hotelClerk.getRealtimeCollections.called).be.true();
-          should(kuzzle.services.list.storageEngine.listCollections.called).be.true();
+          should(kuzzle.hotelClerk.getRealtimeCollections).be.called();
+          should(kuzzle.services.list.storageEngine.listCollections).be.called();
         });
     });
 
@@ -495,8 +495,8 @@ describe('Test: collection controller', () => {
             {name: 'estored', type: 'stored'}
           ]);
           should(response).be.instanceof(Object);
-          should(kuzzle.hotelClerk.getRealtimeCollections.called).be.true();
-          should(kuzzle.services.list.storageEngine.listCollections.called).be.true();
+          should(kuzzle.hotelClerk.getRealtimeCollections).be.called();
+          should(kuzzle.services.list.storageEngine.listCollections).be.called();
         });
     });
 
@@ -515,8 +515,8 @@ describe('Test: collection controller', () => {
             {name: 'astored', type: 'stored'}
           ]);
           should(response.type).be.exactly('all');
-          should(kuzzle.hotelClerk.getRealtimeCollections.called).be.true();
-          should(kuzzle.services.list.storageEngine.listCollections.called).be.true();
+          should(kuzzle.hotelClerk.getRealtimeCollections).be.called();
+          should(kuzzle.services.list.storageEngine.listCollections).be.called();
         });
     });
 

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -125,7 +125,7 @@ describe('funnelController.execute', () => {
       funnel.execute(request, callback);
 
       should(funnel.overloaded).be.true();
-      should(funnel.processRequest.called).be.false();
+      should(funnel.processRequest).not.be.called();
       should(funnel.requestsCacheQueue.length).be.eql(1);
       should(funnel.requestsCacheQueue.shift()).eql(request.internalId);
       should(funnel.requestsCacheById[request.internalId]).eql(new (FunnelController.__get__('CacheItem'))('execute', request, callback));
@@ -155,7 +155,7 @@ describe('funnelController.execute', () => {
       funnel.execute(request, callback);
 
       should(funnel.overloaded).be.true();
-      should(funnel.processRequest.called).be.false();
+      should(funnel.processRequest).not.be.called();
       should(funnel.requestsCacheQueue.length).be.eql(1);
       should(funnel.requestsCacheQueue.shift()).be.eql(request.internalId);
       should(funnel.requestsCacheById[request.internalId]).match({request, callback});
@@ -183,7 +183,7 @@ describe('funnelController.execute', () => {
       funnel.execute(request, (err, res) => {
         should(funnel.overloaded).be.true();
         should(funnel._playCachedRequests).have.callCount(0);
-        should(funnel.processRequest.called).be.false();
+        should(funnel.processRequest).not.be.called();
         should(funnel.requestsCacheQueue.length).be.eql(kuzzle.config.limits.requestsBufferSize);
         should(err).be.instanceOf(ServiceUnavailableError);
         should(err.status).be.eql(503);
@@ -200,8 +200,8 @@ describe('funnelController.execute', () => {
       funnel.checkRights.throws(new Error('funnel.checkRights should not have been called'));
 
       should(funnel.execute(request, cb)).be.eql(0);
-      should(funnel.checkRights.called).be.false();
-      should(cb.called).be.false();
+      should(funnel.checkRights).not.be.called();
+      should(cb).not.be.called();
     });
   });
 

--- a/test/api/controllers/funnelController/executePluginRequest.test.js
+++ b/test/api/controllers/funnelController/executePluginRequest.test.js
@@ -28,7 +28,7 @@ describe('funnelController.executePluginRequest', () => {
         should(res).be.undefined();
         should(err).be.instanceOf(BadRequestError);
         should(err.message).be.eql('Unknown controller foo');
-        should(kuzzle.pluginsManager.trigger.called).be.false();
+        should(kuzzle.pluginsManager.trigger).not.be.called();
         done();
       }
       catch (e) {
@@ -52,7 +52,7 @@ describe('funnelController.executePluginRequest', () => {
         should(err).be.null();
         should(res).be.eql(rq);
         should(rq.status).be.eql(333);
-        should(kuzzle.pluginsManager.trigger.called).be.false();
+        should(kuzzle.pluginsManager.trigger).not.be.called();
         done();
       }
       catch (e) {
@@ -75,8 +75,8 @@ describe('funnelController.executePluginRequest', () => {
         should(err).be.eql(error);
         should(res).be.undefined();
         should(rq.status).be.eql(500);
-        should(funnel.handleErrorDump.called).be.true();
-        should(kuzzle.pluginsManager.trigger.called).be.false();
+        should(funnel.handleErrorDump).be.called();
+        should(kuzzle.pluginsManager.trigger).not.be.called();
         done();
       }
       catch (e) {

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -40,7 +40,7 @@ describe('funnelController.processRequest', () => {
     should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'Unknown controller null'});
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-    should(kuzzle.statistics.startRequest.called).be.false();
+    should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if no action is specified', () => {
@@ -49,7 +49,7 @@ describe('funnelController.processRequest', () => {
     should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action null in controller fakeController'});
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-    should(kuzzle.statistics.startRequest.called).be.false();
+    should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if the action doesn\'t exist', () => {
@@ -59,7 +59,7 @@ describe('funnelController.processRequest', () => {
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorCreate', request)).be.false();
-    should(kuzzle.statistics.startRequest.called).be.false();
+    should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if a plugin action does not exist', () => {
@@ -69,7 +69,7 @@ describe('funnelController.processRequest', () => {
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorCreate', request)).be.false();
-    should(kuzzle.statistics.startRequest.called).be.false();
+    should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if a plugin action returns a non-thenable object', done => {
@@ -86,7 +86,7 @@ describe('funnelController.processRequest', () => {
           should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
           should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
           should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorOk', request)).be.true();
-          should(kuzzle.statistics.startRequest.called).be.true();
+          should(kuzzle.statistics.startRequest).be.called();
           done();
         }
         catch(err) {
@@ -109,9 +109,9 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.true();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorOk', request)).be.false();
-        should(kuzzle.statistics.startRequest.called).be.true();
-        should(kuzzle.statistics.completedRequest.called).be.true();
-        should(kuzzle.statistics.failedRequest.called).be.false();
+        should(kuzzle.statistics.startRequest).be.called();
+        should(kuzzle.statistics.completedRequest).be.called();
+        should(kuzzle.statistics.failedRequest).not.be.called();
       })).be.fulfilled();
   });
 
@@ -134,9 +134,9 @@ describe('funnelController.processRequest', () => {
           should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
           should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
           should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorFail', request)).be.true();
-          should(kuzzle.statistics.startRequest.called).be.true();
-          should(kuzzle.statistics.completedRequest.called).be.false();
-          should(kuzzle.statistics.failedRequest.called).be.true();
+          should(kuzzle.statistics.startRequest).be.called();
+          should(kuzzle.statistics.completedRequest).not.be.called();
+          should(kuzzle.statistics.failedRequest).be.called();
           done();
         }
         catch(err) {
@@ -164,9 +164,9 @@ describe('funnelController.processRequest', () => {
           should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
           should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
           should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorFail', request)).be.true();
-          should(kuzzle.statistics.startRequest.called).be.true();
-          should(kuzzle.statistics.completedRequest.called).be.false();
-          should(kuzzle.statistics.failedRequest.called).be.true();
+          should(kuzzle.statistics.startRequest).be.called();
+          should(kuzzle.statistics.completedRequest).not.be.called();
+          should(kuzzle.statistics.failedRequest).be.called();
           done();
         }
         catch(err) {

--- a/test/api/controllers/memoryStorageController.test.js
+++ b/test/api/controllers/memoryStorageController.test.js
@@ -689,7 +689,7 @@ describe('Test: memoryStorage controller', () => {
     });
 
     it('custom mapping checks - geohash', () => {
-      const 
+      const
         req = new Request({
           _id: 'myKey',
           members: ['foo', 'bar', 'baz']

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -25,7 +25,10 @@ describe('Test: routerController.httpRequest', () => {
       pluginsManager: {
         routes: [
           {verb: 'get', url: 'foo/bar/baz', controller: 'foo', action: 'bar'}
-        ]
+        ],
+        trigger: function (event, request) {
+          return Promise.resolve(request);
+        }
       },
       funnel: {
         execute: function (request, cb) {

--- a/test/api/core/auth/passportWrapper.test.js
+++ b/test/api/core/auth/passportWrapper.test.js
@@ -134,7 +134,7 @@ describe('Test the passport Wrapper', () => {
         should(response).be.an.instanceOf(PassportResponse);
         should(response.statusCode).be.equal(302);
         should(response.getHeader('Location')).be.equal('http://example.org');
-        should(stub.called).be.false();
+        should(stub).not.be.called();
       });
   });
 

--- a/test/api/core/hotelClerk/removeRoomForCustomer.test.js
+++ b/test/api/core/hotelClerk/removeRoomForCustomer.test.js
@@ -49,7 +49,7 @@ describe ('lib/core/hotelclerk:removeRoomForCustomer', () => {
     should(() => hotelClerk._removeRoomForCustomer(requestContext, 'roomId')).throw(NotFoundError);
     should(hotelClerk.rooms.roomId).not.be.undefined();
     should(hotelClerk.roomsCount).be.eql(1);
-    should(kuzzle.notifier.notifyUser.called).be.false();
+    should(kuzzle.notifier.notifyUser).not.be.called();
   });
 
   it('should remove the room from the customer list and remove the connection entry if empty', () => {
@@ -67,7 +67,7 @@ describe ('lib/core/hotelclerk:removeRoomForCustomer', () => {
     should(hotelClerk.rooms).be.an.Object().and.be.empty();
 
     // should not notify since nobody else is listening
-    should(kuzzle.notifier.notifyUser.called).be.false();
+    should(kuzzle.notifier.notifyUser).not.be.called();
   });
 
   it('should remove the room from the customer list and keep other existing rooms', () => {
@@ -90,7 +90,7 @@ describe ('lib/core/hotelclerk:removeRoomForCustomer', () => {
     should(hotelClerk.roomsCount).be.eql(1);
 
     // should not notify since nobody else is listening
-    should(kuzzle.notifier.notifyUser.called).be.false();
+    should(kuzzle.notifier.notifyUser).not.be.called();
   });
 
   it('should remove a customer and notify other users in the room', () => {

--- a/test/api/core/hotelClerk/removeSubscription.test.js
+++ b/test/api/core/hotelClerk/removeSubscription.test.js
@@ -68,7 +68,7 @@ describe('Test: hotelClerk.removeSubscription', () => {
 
     should(kuzzle.realtime.remove).be.calledOnce();
 
-    should(kuzzle.notifier.notifyUser.called).be.false();
+    should(kuzzle.notifier.notifyUser).not.be.called();
 
     should(hotelClerk.roomsCount).be.eql(1);
 
@@ -93,7 +93,7 @@ describe('Test: hotelClerk.removeSubscription', () => {
       .be.calledOnce()
       .be.calledWith(unsubscribeRequest.input.body.roomId);
 
-    should(kuzzle.notifier.notifyUser.called).be.false();
+    should(kuzzle.notifier.notifyUser).not.be.called();
 
     should(hotelClerk.rooms).be.an.Object().and.be.empty();
     should(hotelClerk.customers).be.an.Object().and.be.empty();
@@ -106,7 +106,7 @@ describe('Test: hotelClerk.removeSubscription', () => {
     hotelClerk.rooms.foo.customers.add('another connection');
     hotelClerk.removeSubscription(unsubscribeRequest, context);
 
-    should(kuzzle.realtime.remove.called).be.false();
+    should(kuzzle.realtime.remove).not.be.called();
     should(kuzzle.notifier.notifyUser).be.calledOnce();
     should(hotelClerk.roomsCount).be.eql(2);
 

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -132,7 +132,7 @@ describe('Test: security/userTest', () => {
       .then(isActionAllowed => {
         should(isActionAllowed).be.a.Boolean();
         should(isActionAllowed).be.true();
-        should(profile.isActionAllowed.called).be.true();
+        should(profile.isActionAllowed).be.called();
       });
   });
 
@@ -142,7 +142,7 @@ describe('Test: security/userTest', () => {
       .then(isActionAllowed => {
         should(isActionAllowed).be.a.Boolean();
         should(isActionAllowed).be.false();
-        should(profile.isActionAllowed.called).be.false();
+        should(profile.isActionAllowed).not.be.called();
       });
   });
 

--- a/test/api/core/notifier/notifyDocumentMDelete.test.js
+++ b/test/api/core/notifier/notifyDocumentMDelete.test.js
@@ -31,7 +31,7 @@ describe('Test: notifier.notifyDocumentMDelete', () => {
   it('should do nothing if no id is provided', () => {
     return notifier.notifyDocumentMDelete(request, [])
       .then(() => {
-        should(notifier.notifyDocument.called).be.false();
+        should(notifier.notifyDocument).not.be.called();
       });
   });
 

--- a/test/api/core/notifier/notifyMethods.test.js
+++ b/test/api/core/notifier/notifyMethods.test.js
@@ -56,8 +56,8 @@ describe('notify methods', () => {
 
       async.retry({times: 20, interval: 20}, cb => {
         try {
-          should(kuzzle.entryPoints.dispatch.called).be.false();
-          should(kuzzle.pluginsManager.trigger.called).be.false();
+          should(kuzzle.entryPoints.dispatch).not.be.called();
+          should(kuzzle.pluginsManager.trigger).not.be.called();
           cb();
         }
         catch(e) {
@@ -142,7 +142,7 @@ describe('notify methods', () => {
 
       async.retry({times: 20, interval: 20}, cb => {
         try {
-          should(kuzzle.entryPoints.dispatch.called).be.false();
+          should(kuzzle.entryPoints.dispatch).not.be.called();
           cb();
         }
         catch(e) {
@@ -158,7 +158,7 @@ describe('notify methods', () => {
 
       async.retry({times: 20, interval: 20}, cb => {
         try {
-          should(kuzzle.entryPoints.dispatch.called).be.false();
+          should(kuzzle.entryPoints.dispatch).not.be.called();
           cb();
         }
         catch(e) {
@@ -172,7 +172,7 @@ describe('notify methods', () => {
 
       async.retry({times: 20, interval: 20}, cb => {
         try {
-          should(kuzzle.entryPoints.dispatch.called).be.false();
+          should(kuzzle.entryPoints.dispatch).not.be.called();
           cb();
         }
         catch(e) {
@@ -240,8 +240,8 @@ describe('notify methods', () => {
 
       async.retry({times: 20, interval: 20}, cb => {
         try {
-          should(kuzzle.entryPoints.dispatch.called).be.false();
-          should(kuzzle.pluginsManager.trigger.called).be.false();
+          should(kuzzle.entryPoints.dispatch).not.be.called();
+          should(kuzzle.pluginsManager.trigger).not.be.called();
           cb();
         }
         catch(e) {
@@ -255,8 +255,8 @@ describe('notify methods', () => {
 
       async.retry({times: 20, interval: 20}, cb => {
         try {
-          should(kuzzle.entryPoints.dispatch.called).be.false();
-          should(kuzzle.pluginsManager.trigger.called).be.false();
+          should(kuzzle.entryPoints.dispatch).not.be.called();
+          should(kuzzle.pluginsManager.trigger).not.be.called();
           cb();
         }
         catch(e) {

--- a/test/api/core/notifier/publish.test.js
+++ b/test/api/core/notifier/publish.test.js
@@ -124,7 +124,7 @@ describe('Test: notifier.publish', () => {
 
     const result = notifier.publish(new Request(rawRequest), 'foo', 'bar');
 
-    should(notifier.notifyDocument.called).be.false();
+    should(notifier.notifyDocument).not.be.called();
     should(result).match({published: true});
 
     should(kuzzle.services.list.internalCache.setex).not.be.called();

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -336,7 +336,7 @@ describe('Plugin Context', () => {
         callback = sinon.spy(
           (err, res) => {
             try {
-              should(kuzzle.funnel.executePluginRequest.called).be.false();
+              should(kuzzle.funnel.executePluginRequest).not.be.called();
               should(callback).be.calledOnce();
               should(err).be.instanceOf(PluginImplementationError);
               should(err.message).startWith('Invalid argument: a Request object must be supplied');

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -442,7 +442,7 @@ describe('Test: ElasticSearch service', () => {
           try {
             should(err).be.an.instanceOf(NotFoundError);
             should(err.message).be.exactly(`Document with id "${request.input.resource._id}" not found.`);
-            should(elasticsearch.client.index.called).be.false();
+            should(elasticsearch.client.index).not.be.called();
 
             done();
           }
@@ -1717,7 +1717,7 @@ describe('Test: ElasticSearch service', () => {
 
       return elasticsearch.refreshIndexIfNeeded({index: request.input.resource.index}, {foo: 'bar'})
         .then(response => {
-          should(elasticsearch.client.indices.refresh.called).be.false();
+          should(elasticsearch.client.indices.refresh).not.be.called();
           should(response).be.eql({ foo: 'bar' });
         });
     });
@@ -1728,7 +1728,7 @@ describe('Test: ElasticSearch service', () => {
 
       return elasticsearch.refreshIndexIfNeeded({index: request.input.resource.index}, {foo: 'bar'})
         .then(response => {
-          should(elasticsearch.client.indices.refresh.called).be.true();
+          should(elasticsearch.client.indices.refresh).be.called();
           should(response).be.eql({foo: 'bar'});
         });
     });
@@ -1744,7 +1744,7 @@ describe('Test: ElasticSearch service', () => {
       return elasticsearch.refreshIndexIfNeeded({index: request.input.resource.index}, {foo: 'bar'})
         .then(response => {
           should(pluginSpy.calledWith('log:error')).be.true();
-          should(elasticsearch.client.indices.refresh.called).be.true();
+          should(elasticsearch.client.indices.refresh).be.called();
           should(response).be.eql({ foo: 'bar' });
           return null;
         });

--- a/test/services/redis.test.js
+++ b/test/services/redis.test.js
@@ -320,7 +320,7 @@ describe('Test redis service', () => {
     sandbox.stub(IORedis, 'Cluster').returns({});
 
     Redis.__get__('buildClient')(config);
-    should(IORedis.Cluster.called).be.true();
+    should(IORedis.Cluster).be.called();
   });
 
   it('should build a client instance of Redis if only one node is defined', () => {
@@ -331,6 +331,6 @@ describe('Test redis service', () => {
     sandbox.stub(IORedis, 'Cluster').returns({});
 
     Redis.__get__('buildClient')(config);
-    should(IORedis.Cluster.called).be.false();
+    should(IORedis.Cluster).not.be.called();
   });
 });


### PR DESCRIPTION
_This is a test for CodeRabbit PR review assistant. Original PR https://github.com/kuzzleio/kuzzle/pull/1108_

## What does this PR do ?
<!-- Please fulfill this section -->

This PR add 6 events related to the HTTP method used. `http:get`, `http:post`, `http:put`, `http:patch`, `http:delete`, `http:head` (`http:options` was already present).  
See [Jira#KZL-42](https://jira.kaliop.net/browse/KZL-42) or https://github.com/kuzzleio/kuzzle/issues/1099 for more context.  

The events are fired in `Router.route().  

Changes are documented here : https://github.com/kuzzleio/documentation/pull/478

### How should this be manually tested?

  - Step 1 : Run a Kuzzle stack with plugins debug : `DEBUG=kuzzle:plugins docker-compose -f docker-compose/dev.yml up`
  - Step 2 : Try running a curl request and verify if the correct event is fired : `curl -X PUT localhost:7512`
![image](https://user-images.githubusercontent.com/4447392/39704970-480dd522-520d-11e8-9e4c-ba5019549e15.png)

  - Step 3 : Repeat with all HTTP methods: `methods=(GET POST PUT PATCH DELETE HEAD); for method in $methods; do curl -X $method localhost:7512/_getInfo; done`

### Boyscout

 - Fix listener arguments on `unhandledRejection` (Related to #1020 )
 - Fix `should().be.called()` syntax in tests
 - Allow user to remove `node_modules` created by docker without `sudo`
 - Replace references to back-office by admin console
